### PR TITLE
Fixed incorrect success message on repo options page.

### DIFF
--- a/public/js/pullreq.js
+++ b/public/js/pullreq.js
@@ -225,7 +225,7 @@ var Pullreq = Pullreq || {};
             data: {
                 successMessage: '<div class="alert alert-success">' +
                     '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
-                    '<strong>Bravo!</strong> You have successfully saved your warning paths.' +
+                    '<strong>Bravo!</strong> You have successfully saved your chosen repositories.' +
                     '</div>',
                 warningMessage: '<div class="alert alert-error">' +
                     '<button type="button" class="close" data-dismiss="alert">&times;</button>' +


### PR DESCRIPTION
Modified pullreq.js to properly supply a page-specific success message
for saving repository options instead of duplicating the warning paths
message. A minor annoyance.
