### PR TITLE
Adding a file to build a docker container and simple makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Quick docker file that can be used to create an image of the local working files.
+# For help building see the make Makefile in the current directory.
+
+FROM ubuntu:14.04
+
+RUN apt-get update
+RUN apt-get -y install nodejs nodejs-legacy npm
+ADD docker-build /app
+WORKDIR /app
+RUN npm install
+RUN ./node_modules/bower/bin/bower install --allow-root --force --config.interactive=0
+RUN ./node_modules/grunt-cli/bin/grunt prod-assemble
+ENTRYPOINT node src/js/server/server.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Simple make file to package up a docker instance. To use just you can just type:
+#   make build
+# Or if you want to name your container you can instead type something like
+#   make build image="adanperez/pullreq"
+#
+# That will create a new directory docker-build, copy the working files there, and
+# then kick off a docker build.
+
+.PHONY : build all
+
+temp_dir = docker-build
+image = pullreq
+
+build: clean
+	mkdir $(temp_dir)
+	cp -r public src .bowerrc bower.json Gruntfile.js package.json README.md  $(temp_dir)/
+	docker build -t $(image) .
+	rm -rf $(temp_dir)
+
+clean:
+	rm -rf $(temp_dir)


### PR DESCRIPTION
I got this working so I can test out how nodejs will work in
side of docker, and maybe start to use docker for deploying
nodejs apps internally. This should work and I had pullreq
running 100% locally.

Once you have docker working you should be able to just do
a `make build` to kick off the docker build.  And then you can
run the container by doing something like:

docker run -it \
    -p 9095:9095 \
    -e PORT=9095 \
    -e MONGOLAB_URI="mongodb://xxxx/pullreq" \
    -e SESSION_SECRET="xyz" \
    -e GITHUB_CLIENT_ID="your_client" \
    -e GITHUB_CLIENT_SECRET="your_secret" \
    charliek/pullreq
